### PR TITLE
fix: product taxes (WEE/FPT) are not used from simple products

### DIFF
--- a/app/code/Magento/WeeeConfigurableProducts/Model/Total/Quote/Weee.php
+++ b/app/code/Magento/WeeeConfigurableProducts/Model/Total/Quote/Weee.php
@@ -1,0 +1,24 @@
+<?php
+namespace Magento\WeeeConfigurableProducts\Model\Total\Quote;
+ 
+/**
+ * Class TotalQuoteWeee
+ */
+class Weee extends \Magento\Weee\Model\Total\Quote\Weee
+{
+    /**
+     * @param \Magento\Quote\Model\Quote\Address $address
+     * @param \Magento\Quote\Model\Quote\Address\Total $total
+     * @param \Magento\Quote\Model\Quote\Item\AbstractItem $item
+     */
+    protected function process(
+        \Magento\Quote\Model\Quote\Address $address,
+        \Magento\Quote\Model\Quote\Address\Total $total,
+        $item
+    ) {
+        // Add a reference to the quote item on the product model:
+        $item->getProduct()->setQuoteItem($item);
+
+        parent::process($address, $total, $item);
+    }
+}

--- a/app/code/Magento/WeeeConfigurableProducts/Plugin/WeeeTax.php
+++ b/app/code/Magento/WeeeConfigurableProducts/Plugin/WeeeTax.php
@@ -1,0 +1,77 @@
+<?php
+namespace Magento\WeeeConfigurableProducts\Plugin;
+
+use Magento\Store\Model\Website;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Type;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+
+/**
+ * Class Tax makes sure that the FPT of the simple products is used.
+ */
+class WeeeTax
+{
+    /**
+     * @var ProductRepositoryInterface
+     */
+    protected $productRepository;
+
+    /**
+     * Tax constructor.
+     * @param ProductRepositoryInterface $productRepository
+     */
+    public function __construct(
+        ProductRepositoryInterface $productRepository
+    ) {
+        $this->productRepository = $productRepository;
+    }
+
+    /**
+     * @param \Magento\Weee\Model\Tax $subject
+     * @param callable $proceed
+     * @param Product $product
+     * @param null|false|\Magento\Quote\Model\Quote\Address $shipping
+     * @param null|false|\Magento\Quote\Model\Quote\Address $billing
+     * @param Website $website
+     * @param bool $calculateTax
+     * @param bool $round
+     * @return mixed
+     */
+    public function aroundGetProductWeeeAttributes(
+        \Magento\Weee\Model\Tax $subject,
+        callable $proceed,
+        Product $product,
+        $shipping = null,
+        $billing = null,
+        $website = null,
+        $calculateTax = null,
+        $round = true
+    ) {
+        if ($product->getTypeId() === Configurable::TYPE_CODE) {
+            $simpleId = false;
+
+            /** @var Item $quoteItem */
+            $quoteItem = $product->getQuoteItem();
+            if ($quoteItem) {
+                $itemsCollection = $quoteItem->getQuote()->getItemsCollection();
+                foreach ($itemsCollection as $item) {
+                    if ($item->getProductType() !== Type::TYPE_SIMPLE) {
+                        continue;
+                    }
+                    if ($item->getParentItemId() == $quoteItem->getId()) {
+                        $simpleId = $item->getProductId();
+                        break;
+                    }
+                }
+            }
+
+            if ($simpleId) {
+                $product = $this->productRepository->getById($simpleId);
+            }
+        }
+
+        $result = $proceed($product, $shipping, $billing, $website, $calculateTax, $round);
+        return $result;
+    }
+}

--- a/app/code/Magento/WeeeConfigurableProducts/composer.json
+++ b/app/code/Magento/WeeeConfigurableProducts/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "artbambou/magento2-module-weee-configurable-products",
+    "description": "N/A",
+    "type": "magento2-module",
+    "license": [
+        "OSL-3.0",
+        "AFL-3.0"
+    ],
+    "require": {
+        "php": "~7.4.0||~8.1.0",
+        "magento/framework": "*",
+        "magento/module-configurable-product": "*",
+        "magento/module-weee": "*"
+	},
+    "autoload": {
+        "files": [
+            "registration.php"
+        ],
+        "psr-4": {
+            "Magento\\WeeeConfigurableProducts\\": ""
+        }
+    }
+}

--- a/app/code/Magento/WeeeConfigurableProducts/etc/di.xml
+++ b/app/code/Magento/WeeeConfigurableProducts/etc/di.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="Magento\Weee\Model\Total\Quote\Weee" type="Magento\WeeeConfigurableProducts\Model\Total\Quote\Weee" />
+    <type name="Magento\Weee\Model\Tax">
+        <plugin type="Magento\WeeeConfigurableProducts\Plugin\WeeeTax" name="WeeeConfigurablesProducts_Tax" />
+    </type>
+</config>

--- a/app/code/Magento/WeeeConfigurableProducts/etc/module.xml
+++ b/app/code/Magento/WeeeConfigurableProducts/etc/module.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Magento_WeeeConfigurableProducts">
+	    <sequence>
+            <module name="Magento_Weee" />
+            <module name="Magento_ConfigurableProducts" />
+        </sequence>
+    </module>
+</config>

--- a/app/code/Magento/WeeeConfigurableProducts/registration.php
+++ b/app/code/Magento/WeeeConfigurableProducts/registration.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Copyright © Ilan Parmentier, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_WeeeConfigurableProducts', __DIR__);


### PR DESCRIPTION
Good afternoon,

This is a step from a concrete pull request.
All the credits go to @kanduvisla, author of this patch.

### Issue :

We were missing the Fixed Product Taxes (a.k.a FPT) or WEEE prices in the checkout cart (summary and page) and checkout processing.
Please note, the FPT is still not displaying in the product info page which can disturb customers.

### Related Pull Requests

Resolve the issue described in :
#4774
#25554
#28931

### Manual testing scenarios (*)

Enable FPT - Stores - sales -tax- Enable fixed product tax
Create a new attribute (code: dynamic_weight_rate / type: fixed product tax)
Create a new "attribute set" and assign an attribute to it
Assign attribute set to a configurable product (previously created or a new one)
Update FPT information on each simple product related to configurable one
On front-office, try to add a configurable product to the cart
No FPT row on summary cart, cart and checkout process is added.

### Questions or comments

Problems of the current implentation of this code :

This current code use around plugin and load one simple product from each configurable products which can harms the performance.

Not particulary at ease with the current implentation as the others products type (Pricing models, etc.) implentation but I wanna particulary goes up this issue to the community and Magento teams whose has closed issues.